### PR TITLE
Error handler

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -72,4 +72,6 @@ gem 'faker', '~> 2.19.0', git: 'https://github.com/faker-ruby/faker.git', branch
 
 gem 'jwt', '~> 2.3'
 
-gem "blueprinter", "~> 0.25.3"
+# For serialization
+
+gem 'blueprinter', '~> 0.25.3'

--- a/Gemfile
+++ b/Gemfile
@@ -72,5 +72,4 @@ gem 'faker', '~> 2.19.0', git: 'https://github.com/faker-ruby/faker.git', branch
 
 gem 'jwt', '~> 2.3'
 
-# For tests (will be removed in next version)
-gem 'jsonapi-serializer', '~> 2.2.0'
+gem "blueprinter", "~> 0.25.3"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -70,6 +70,7 @@ GEM
       zeitwerk (~> 2.3)
     ast (2.4.2)
     bcrypt (3.1.16)
+    blueprinter (0.25.3)
     bootsnap (1.9.1)
       msgpack (~> 1.0)
     builder (3.2.4)
@@ -218,6 +219,7 @@ PLATFORMS
 
 DEPENDENCIES
   bcrypt (~> 3.1)
+  blueprinter (~> 0.25.3)
   bootsnap (>= 1.4.4)
   byebug
   dotenv-rails (~> 2.7.6)

--- a/app/controllers/api/v1/tokens_controller.rb
+++ b/app/controllers/api/v1/tokens_controller.rb
@@ -3,7 +3,7 @@
 class Api::V1::TokensController < ApplicationController
   def create
     authenticated = user&.authenticate(user_params[:password])
-    return head :unauthorized unless authenticated
+    return render_error(4011) unless authenticated
 
     render json: {
       token: JsonWebToken.encode(user_id: user.id),

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -5,14 +5,14 @@ class Api::V1::UsersController < ApplicationController
 
   # GET /users/1
   def show
-    render json: UserSerializer.new(user).serializable_hash
+    render json: UserSerializer.render(user)
   end
 
   # POST /users
   def create
     user = User.new(user_params)
     if user.save
-      render json: UserSerializer.new(user).serializable_hash, status: :created
+      render json: UserSerializer.render(user), status: :created
     else
       render_error(4022, user.errors.messages[:error])
     end
@@ -21,7 +21,7 @@ class Api::V1::UsersController < ApplicationController
   # PATCH/PUT /users/1
   def update
     if user.update(user_params)
-      render json: UserSerializer.new(user).serializable_hash, status: :ok
+      render json: UserSerializer.render(user), status: :ok
     else
       render_error(4022, user.errors.messages[:error])
     end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -60,6 +60,6 @@ class Api::V1::UsersController < ApplicationController
   end
 
   def check_owner
-    head :unauthorized unless user.id == current_user&.id
+    render_error(4011) unless user.id == current_user&.id
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -23,7 +23,7 @@ class Api::V1::UsersController < ApplicationController
     if user.update(user_params)
       render json: UserSerializer.render(user), status: :ok
     else
-      render_error(4022, user.errors.messages[:error])
+      render_error(4023, user.errors.messages[:error])
     end
   end
 

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -45,7 +45,7 @@ class Api::V1::UsersController < ApplicationController
   end
 
   rescue_from AuthenticationError do
-    render json: { error: 'Authentication error' }, status: :unauthorized
+    render_error(4011)
   end
 
   private

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -14,7 +14,7 @@ class Api::V1::UsersController < ApplicationController
     if user.save
       render json: UserSerializer.new(user).serializable_hash, status: :created
     else
-      render json: user.errors, status: :unprocessable_entity
+      render_error(4022, user.errors.messages[:error])
     end
   end
 
@@ -23,7 +23,7 @@ class Api::V1::UsersController < ApplicationController
     if user.update(user_params)
       render json: UserSerializer.new(user).serializable_hash, status: :ok
     else
-      render json: user.errors, status: :unprocessable_entity
+      render_error(4022, user.errors.messages[:error])
     end
   end
 
@@ -33,14 +33,14 @@ class Api::V1::UsersController < ApplicationController
     head :no_content
   end
 
-  rescue_from ActiveRecord::RecordNotFound do
+  rescue_from ActiveRecord::RecordNotFound do |exception|
     # TODO: Add error message
     # If current_user raise this exception for delete or update, it means that the user is not logged in
     # (and therefore not authorized to access this resource)
     if request.delete? || request.put?
-      head :unauthorized
+      render_error(4010, exception.message)
     else
-      render json: { error: 'User not found' }, status: :not_found
+      render_error(4000, exception.message)
     end
   end
 

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,4 +2,5 @@
 
 class ApplicationController < ActionController::API
   include Authenticable
+  include ErrorHandler
 end

--- a/app/controllers/concerns/authenticable.rb
+++ b/app/controllers/concerns/authenticable.rb
@@ -8,8 +8,8 @@ module Authenticable
     return nil if header.nil?
 
     @current_user = begin
-                      decoded = JsonWebToken.decode(header)
-                      User.find(decoded[:user_id])
+                        decoded = JsonWebToken.decode(header.split(' ').last)
+                        User.find(decoded[:user_id])
     rescue StandardError
         raise AuthenticationError
     end

--- a/app/controllers/concerns/error_handler.rb
+++ b/app/controllers/concerns/error_handler.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ErrorHandler
+  def render_error(error_code, details = {})
+    render json: Api::V1::ErrorSerializer.render(
+      Error.instance.error_for(error_code, details)
+    ), status: Error.instance.http_status_for(error_code)
+  end
+end

--- a/app/serializers/api/v1/error_serializer.rb
+++ b/app/serializers/api/v1/error_serializer.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class Api::V1::ErrorSerializer < Blueprinter::Base
+  fields :description, :error_code, :http_status
+
+  field :details, if: ->(_field_name, error, _options) { error[:details].present? }
+end

--- a/app/serializers/user_serializer.rb
+++ b/app/serializers/user_serializer.rb
@@ -1,6 +1,5 @@
 # frozen_string_literal: true
 
-class UserSerializer
-  include JSONAPI::Serializer
-  attributes :email
+class UserSerializer < Blueprinter::Base
+  field :email
 end

--- a/config/errors.yaml
+++ b/config/errors.yaml
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+5000:
+  :http_status: 500
+  :error_code: 5000
+  :description: 'Internal server error'
+4000:
+  :http_status: 404
+  :error_code: 4000
+  :description: 'Not found'
+4001:
+  :http_status: 400
+  :error_code: 4001
+  :description: 'Missing Parameter'
+4010:
+  :http_status: 401
+  :error_code: 4010
+  :description: 'You are not authorized to do this action'

--- a/config/errors.yaml
+++ b/config/errors.yaml
@@ -15,8 +15,12 @@
 4010:
   :http_status: 401
   :error_code: 4010
-  :description: 'You are not authorized to do this action'
+  :description: 'User can not be deleted or updated due to user not found'
 4022:
   :http_status: 422
   :error_code: 4022
-  :description: 'Invalid Parameter'
+  :description: 'Cannot create profile due to invalid paramater'
+4023:
+  :http_status: 422
+  :error_code: 4023
+  :description: 'Cannot update profile due to invalid paramater'

--- a/config/errors.yaml
+++ b/config/errors.yaml
@@ -16,3 +16,7 @@
   :http_status: 401
   :error_code: 4010
   :description: 'You are not authorized to do this action'
+4022:
+  :http_status: 422
+  :error_code: 4022
+  :description: 'Invalid Parameter'

--- a/config/errors.yaml
+++ b/config/errors.yaml
@@ -13,9 +13,13 @@
   :error_code: 4001
   :description: 'Missing Parameter'
 4010:
-  :http_status: 401
+  :http_status: 404
   :error_code: 4010
   :description: 'User can not be deleted or updated due to user not found'
+4011:
+  :http_status: 401
+  :error_code: 4011
+  :description: 'User can not be deleted or updated due to unauthorized'
 4022:
   :http_status: 422
   :error_code: 4022

--- a/lib/error.rb
+++ b/lib/error.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'singleton'
+require 'yaml'
+
+class Error
+  include Singleton
+
+  def error_for(code, details)
+    errors[code][:details] = details if details.present?
+    errors[code]
+  end
+
+  def http_status_for(code)
+    errors[code][:http_status]
+  end
+
+  private
+
+  def errors
+    @errors ||= YAML.load_file(Rails.root.join('config', 'errors.yaml'))
+  end
+end

--- a/spec/controllers/api/v1/tokens_controller_spec.rb
+++ b/spec/controllers/api/v1/tokens_controller_spec.rb
@@ -25,7 +25,7 @@ RSpec.describe Api::V1::TokensController, type: :controller do
     end
 
     context 'when it is unsuccessful' do
-      it 'returns http unprocessable entity' do
+      it 'returns http unauthorized' do
         create_call({ id: user.id, email: user.email, password: 'wrong_password' })
         expect(response).to have_http_status(:unauthorized)
       end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -34,7 +34,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the error message' do
-        expect(JSON.parse(response.body)['error']).to eql('User not found')
+        expect(JSON.parse(response.body)['details']).to eql("Couldn't find User with 'id'=0")
       end
     end
   end
@@ -67,8 +67,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
-      it 'returns a error' do
-        expect(JSON.parse(response.body)['error']).to eql(['is not an email'])
+      it 'returns an error' do
+        expect(JSON.parse(response.body)['details']).to eql(['is not an email'])
       end
     end
   end
@@ -99,8 +99,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
       before { update_user_call(authenticated_user) }
 
-      it 'returns a error' do
-        expect(JSON.parse(response.body)['error']).to eql(['is not an email'])
+      it 'returns an error' do
+        expect(JSON.parse(response.body)['details']).to eql(['is not an email'])
       end
 
       it 'error status is 422' do

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -137,11 +137,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the error code 4010' do
+        request.headers['Authorization'] = 'Bearer sdklhjflasgd'
+        update_user_call(user)
         expect(JSON.parse(response.body)['error_code']).to be(4010)
       end
 
       it 'returns the error message' do
-        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
+        request.headers['Authorization'] = 'Bearer sdklhjflasgd'
+        update_user_call(user)
+        error_message = 'User can not be deleted or updated due to user not found'
+        expect(JSON.parse(response.body)['description']).to eql(error_message)
       end
     end
   end
@@ -170,12 +175,17 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it 'returns the error code 4010' do
-        expect(JSON.parse(response.body)['error_code']).to be(4010)
+      it 'returns the error code 4011' do
+        authenticated_user
+        delete_user_call(user)
+        expect(JSON.parse(response.body)['error_code']).to be(4011)
       end
 
       it 'returns the error message' do
-        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
+        authenticated_user
+        delete_user_call(user)
+        error_message = 'User can not be deleted or updated due to unauthorized'
+        expect(JSON.parse(response.body)['description']).to eql(error_message)
       end
     end
 
@@ -184,6 +194,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         request.headers['Authorization'] = nil
         delete_user_call(user)
         expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the error code 4011' do
+        expect(JSON.parse(response.body)['error_code']).to be(4011)
       end
     end
 
@@ -195,11 +209,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the error code 4010' do
+        request.headers['Authorization'] = 'Bearer sdklhjflasgd'
+        delete_user_call(user)
         expect(JSON.parse(response.body)['error_code']).to be(4010)
       end
 
       it 'returns the error message' do
-        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
+        request.headers['Authorization'] = 'Bearer sdklhjflasgd'
+        delete_user_call(user)
+        error_message = 'User can not be deleted or updated due to user not found'
+        expect(JSON.parse(response.body)['description']).to eql(error_message)
       end
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
       it 'returns the user' do
         # Test to ensure response contains the correct email
-        expect(JSON.parse(response.body)['data']['attributes']['email']).to eql(user.email)
+
+        expect(JSON.parse(response.body)['email']).to eql(user.email)
       end
     end
 
@@ -54,7 +55,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the user' do
-        expect(JSON.parse(response.body)['data']['attributes']['email']).to eql(new_user[:email])
+        expect(JSON.parse(response.body)['email']).to eql(new_user[:email])
       end
     end
 
@@ -90,7 +91,7 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the user' do
-        expect(JSON.parse(response.body)['data']['attributes']['email']).to eql('email@dominio.com')
+        expect(JSON.parse(response.body)['email']).to eql('email@dominio.com')
       end
     end
 

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -37,6 +37,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'returns the error message' do
         expect(JSON.parse(response.body)['details']).to eql("Couldn't find User with 'id'=0")
       end
+
+      it 'returns the error code 4000' do
+        expect(JSON.parse(response.body)['error_code']).to be(4000)
+      end
     end
   end
 
@@ -64,12 +68,16 @@ RSpec.describe Api::V1::UsersController, type: :controller do
 
       before { create_call(new_user) }
 
-      it 'returns code 422' do
+      it 'returns http code 422' do
         expect(response).to have_http_status(:unprocessable_entity)
       end
 
       it 'returns an error' do
         expect(JSON.parse(response.body)['details']).to eql(['is not an email'])
+      end
+
+      it 'returns the error code 4022' do
+        expect(JSON.parse(response.body)['error_code']).to be(4022)
       end
     end
   end
@@ -107,6 +115,10 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'error status is 422' do
         expect(response).to have_http_status(:unprocessable_entity)
       end
+
+      it 'returns the error code 4023' do
+        expect(JSON.parse(response.body)['error_code']).to be(4023)
+      end
     end
 
     context 'when headers are nil' do
@@ -122,6 +134,14 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         update_user_call(user)
         expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the error code 4010' do
+        expect(JSON.parse(response.body)['error_code']).to be(4010)
+      end
+
+      it 'returns the error message' do
+        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
       end
     end
   end
@@ -149,6 +169,14 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         delete_user_call(user)
         expect(response).to have_http_status(:unauthorized)
       end
+
+      it 'returns the error code 4010' do
+        expect(JSON.parse(response.body)['error_code']).to be(4010)
+      end
+
+      it 'returns the error message' do
+        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
+      end
     end
 
     context 'when headers are nil' do
@@ -164,6 +192,14 @@ RSpec.describe Api::V1::UsersController, type: :controller do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         delete_user_call(user)
         expect(response).to have_http_status(:unauthorized)
+      end
+
+      it 'returns the error code 4010' do
+        expect(JSON.parse(response.body)['error_code']).to be(4010)
+      end
+
+      it 'returns the error message' do
+        expect(JSON.parse(response.body)['description']).to eql('User can not be deleted or updated due to user not found')
       end
     end
   end

--- a/spec/controllers/api/v1/users_controller_spec.rb
+++ b/spec/controllers/api/v1/users_controller_spec.rb
@@ -130,22 +130,22 @@ RSpec.describe Api::V1::UsersController, type: :controller do
     end
 
     context 'when token is invalid' do
-      it 'returns forbidden' do
+      it 'returns unauthorized' do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         update_user_call(user)
         expect(response).to have_http_status(:unauthorized)
       end
 
-      it 'returns the error code 4010' do
+      it 'returns the error code 4011' do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         update_user_call(user)
-        expect(JSON.parse(response.body)['error_code']).to be(4010)
+        expect(JSON.parse(response.body)['error_code']).to be(4011)
       end
 
       it 'returns the error message' do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         update_user_call(user)
-        error_message = 'User can not be deleted or updated due to user not found'
+        error_message = 'User can not be deleted or updated due to unauthorized'
         expect(JSON.parse(response.body)['description']).to eql(error_message)
       end
     end
@@ -197,6 +197,8 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       end
 
       it 'returns the error code 4011' do
+        request.headers['Authorization'] = nil
+        delete_user_call(user)
         expect(JSON.parse(response.body)['error_code']).to be(4011)
       end
     end
@@ -211,13 +213,13 @@ RSpec.describe Api::V1::UsersController, type: :controller do
       it 'returns the error code 4010' do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         delete_user_call(user)
-        expect(JSON.parse(response.body)['error_code']).to be(4010)
+        expect(JSON.parse(response.body)['error_code']).to be(4011)
       end
 
       it 'returns the error message' do
         request.headers['Authorization'] = 'Bearer sdklhjflasgd'
         delete_user_call(user)
-        error_message = 'User can not be deleted or updated due to user not found'
+        error_message = 'User can not be deleted or updated due to unauthorized'
         expect(JSON.parse(response.body)['description']).to eql(error_message)
       end
     end


### PR DESCRIPTION
Just review the last three commits:

1. Add error handling (with Blueprinter)
2. Change returns to render_error
3. Change serializer to Blueprinter and remove old gem

The previous commits are from [User auth PR](https://github.com/joaquinvalentin/rails_training/pull/7)

In this branch I've done the error handle. I changed the `jsonapi-serializer` gem to `Blueprinter` because this is more useful for this issue and I see that it's the most common gem for serialization in XL.